### PR TITLE
Add example validation and fix JSON

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,0 +1,10 @@
+# To run validation using a Docker environment:
+#   docker container run $(docker image build -f examples/Dockerfile -q .)
+
+FROM python:3.8-slim
+
+COPY ./examples/requirements.txt /app/examples/requirements.txt
+RUN pip install -r /app/examples/requirements.txt
+ADD ./ /app
+
+CMD ["python", "/app/examples/validate_examples.py"]

--- a/examples/PartialExample_featureGeoJSON.json
+++ b/examples/PartialExample_featureGeoJSON.json
@@ -69,5 +69,57 @@
             }
         ]
     },
-    "properties": {}
+    "properties": {
+        "identifier": "NFZ6547",
+        "country": "FRA",
+        "name": [
+            {"text": "LFPG-2"}
+        ],
+        "variant": "COMMON",
+        "type": "REQ_AUTHORISATION",
+        "reason": [
+            "AIR_TRAFFIC",
+            "OTHER"
+        ],
+        "otherReasonInfo": [
+            {
+                "text": "Flying Whales - part 2",
+                "lang": "en-GB"
+            },
+            {
+                "text": "Baleines Volantes 2-ème partie",
+                "lang": "fr-BE"
+            }
+        ],
+        "limitedApplicability": [
+            {
+                "startDateTime": "2018-12-31T15:59:59Z",
+                "endDateTime": "2019-12-31T15:59:59Z",
+                "schedule": [
+                    {
+                        "day": ["ANY"],
+                        "startTime": "16:00:00Z",
+                        "endTime": "17:00:00Z"
+                    },
+                    {
+                        "day": ["SUN"],
+                        "startTime": "10:00:00Z",
+                        "endTime": "12:00:00Z"
+                    }
+                ]
+            }
+        ],
+        "zoneAuthority": [
+            {
+                "name": [
+                    {
+                        "text": "LFPG-UASZoneManager",
+                        "lang": "en-us"
+                    }
+                ],
+                "email": "UASZoneManager@lfpg.fr",
+                "purpose": "AUTHORIZATION"
+            }
+        ]
+    }
 }

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,2 @@
+jsonschema==4.17.3
+bc-jsonpath-ng==1.5.9

--- a/examples/validate_examples.py
+++ b/examples/validate_examples.py
@@ -1,0 +1,96 @@
+# Validation script to ensure that the examples validate against the defined schema.
+# See Dockerfile to run this script with Docker rather than setting up an environment with requirements.txt.
+
+import os.path
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import List, Optional
+
+import bc_jsonpath_ng
+import jsonschema.validators
+
+
+@dataclass
+class ValidationError(object):
+    """Error encountered while validating an instance against a schema."""
+
+    message: str
+    """Validation error message."""
+
+    json_path: str
+    """Location of the data causing the validation error."""
+
+
+def _collect_errors(e: jsonschema.ValidationError) -> List[ValidationError]:
+    if e.context:
+        result = []
+        for child in e.context:
+            result.extend(_collect_errors(child))
+        return result
+    else:
+        return [ValidationError(message=e.message, json_path=e.json_path)]
+
+
+def validate(schema_path: str, object_path: str, instance: dict, instance_path: Optional[str] = None) -> List[ValidationError]:
+    with open(schema_path, "r") as f:
+        schema_content = json.load(f)
+
+    schema_matches = bc_jsonpath_ng.parse(object_path).find(schema_content)
+    if len(schema_matches) != 1:
+        raise ValueError(
+            f"Found {len(schema_matches)} matches to JSON path '{object_path}' within OpenAPI definition when expecting exactly 1 match"
+        )
+    schema = schema_matches[0].value
+
+    if instance_path is not None:
+        instance_matches = bc_jsonpath_ng.parse(instance_path).find(instance)
+        if len(instance_matches) != 1:
+            raise ValueError(
+                f"Found {len(instance_matches)} matches to JSON path '{instance_path}' within value to validate when expecting exactly 1 match"
+            )
+        value = instance_matches[0].value
+    else:
+        value = instance
+
+    validator_class = jsonschema.validators.validator_for(schema)
+    validator_class.check_schema(schema)
+
+    ref_resolver = jsonschema.RefResolver(f"{Path(schema_path).as_uri()}", schema_content)
+    validator = validator_class(schema, resolver=ref_resolver)
+    result = []
+    for e in validator.iter_errors(value):
+        result.extend(_collect_errors(e))
+    return result
+
+
+def main():
+    root = os.path.realpath(os.path.join(os.path.split(__file__)[0], ".."))
+
+    # (Example file minus extension, JSONPath in example object, schema file minus extension, JSONPath in schema)
+    to_validate = (
+        ("Example_GeoZone_2_Layers",         "$", "Schema_GeoZones",          "$"),
+        ("PartialExample_featureGeoJSON",    "$", "Schema_GeoZones",          "$"),
+        ("PartialExample_GeoZoneProperties", "$", "Schema_GeoZoneProperties", "$"),
+        ("PartialExample_TimePeriod",        "$", "Schema_GeoZoneTimePeriod", "$"),
+        ("PartialExample_ZoneAuthority",     "$", "Schema_GeoZoneAuthority",  "$"),
+    )
+
+    for example, example_jsonpath, schema_file, schema_jsonpath in to_validate:
+        schema_path = os.path.join(root, "schema", schema_file + ".json")
+        instance_path = os.path.join(root, "examples", example + ".json")
+        with open(instance_path, "r") as f:
+            instance_content = json.load(f)
+
+        errors = validate(schema_path, schema_jsonpath, instance_content)
+        if errors:
+            print(f"{example}: {len(errors)} errors found")
+            for e in errors:
+                print(f"  * {e.json_path}: {e.message}")
+                print()
+        else:
+            print(f"{example}: No errors found.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/validate_examples.py
+++ b/examples/validate_examples.py
@@ -82,7 +82,7 @@ def main():
         with open(instance_path, "r") as f:
             instance_content = json.load(f)
 
-        errors = validate(schema_path, schema_jsonpath, instance_content)
+        errors = validate(schema_path, schema_jsonpath, instance_content, example_jsonpath)
         if errors:
             print(f"{example}: {len(errors)} errors found")
             for e in errors:

--- a/schema/Schema_GeoZones.json
+++ b/schema/Schema_GeoZones.json
@@ -25,13 +25,11 @@
                     "oneOf": [
                         {"type": "null"},
                         {
-                            "type": "object",
                             "$ref": "./Schema_GeoZoneProperties.json"
                         }
                     ]
                 },
                 "geometry": {
-                    "type": "object",
                     "$ref": "./Schema_GeoJSONGeometries.json"
                 },
                 "bbox": {
@@ -78,7 +76,6 @@
                                 "oneOf": [
                                     {"type": "null"},
                                     {
-                                        "type": "object",
                                         "$ref": "./Schema_GeoZoneProperties.json"
                                     }
                                 ]
@@ -87,7 +84,6 @@
                                 "oneOf": [
                                     {"type": "null"},
                                     {
-                                        "type": "object",
                                         "$ref": "./Schema_GeoJSONGeometries.json"
                                     }
                                 ]
@@ -114,7 +110,6 @@
         "items": {"type": "number"}
     },
     "metadata": {
-        "type": "object",
         "$ref": "./Schema_GeoZoneCollectionMetadata.json"
     }
 }


### PR DESCRIPTION
Hi Eddie, I'm helping Tim on our side with ED-xxx and was hoping I could help develop the content of this repo to use more directly in the standard.

This PR primarily adds a script (`validate_examples.py`) to validate all the examples against the defined schemas, as well as the infrastructure to run it (`requirements.txt` defining the dependencies and `Dockerfile` defining an environment-agnostic way to run the script).

`PartialExample_featureGeoJSON.json` failed to validate as it was missing the required members of `properties`, so those members were populated with the content of `PartialExample_GeoZoneProperties.json` and now all examples validate.

`$ref` siblings are [not allowed in JSON Schema draft 7](https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-01#section-8.3) ("All other properties in a "$ref" object MUST be ignored."), so this PR also removes `"type": "object",` from the places where it isn't valid in Schema_GeoZones.json.