### PR TITLE
Add LayeredGeoJSON validation

### DIFF
--- a/schema/Schema_GeoJSONGeometries.json
+++ b/schema/Schema_GeoJSONGeometries.json
@@ -1,10 +1,14 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "GeoJSON-Geometries",
-    "oneOf": [
-        {"type": "null"},
+    "title": "Any one of the GeoJSON geometry types, including LayeredGeoJSON validation.",
+  "definitions": {
+    "normalGeometry": {
+      "allOf": [
         {
-            "title": "GeoJSON Point",
+          "oneOf": [
+            {"type": "null"},
+            {
+            "title": "GeoJSON Point with LayeredGeoJSON extent validation",
             "type": "object",
             "required": [
                 "type",
@@ -25,6 +29,24 @@
                     "minItems": 4,
                     "items": {"type": "number"}
                 }
+                },
+                "extent": {
+                  "type": "object",
+                  "required": [
+                    "subType",
+                    "radius"
+                  ],
+                  "properties": {
+                    "subType": {
+                      "type": "string",
+                      "enum": [
+                        "Circle"
+                      ]
+                    },
+                    "radius": {
+                      "type": "number"
+                    }
+                  }
             }
         },
         {
@@ -177,207 +199,53 @@
                     "items": {"type": "number"}
                 }
             }
+            }
+          ]
         },
         {
-            "title": "GeoJSON GeometryCollection",
-            "type": "object",
-            "required": [
-                "type",
-                "geometries"
-            ],
-            "properties": {
-                "type": {
-                    "type": "string",
-                    "enum": ["GeometryCollection"]
-                },
-                "geometries": {
-                    "type": "array",
-                    "items": {
-                        "oneOf": [
-                            {
-                                "title": "GeoJSON Point",
-                                "type": "object",
-                                "required": [
-                                    "type",
-                                    "coordinates"
-                                ],
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": ["Point"]
-                                    },
-                                    "coordinates": {
-                                        "type": "array",
-                                        "minItems": 2,
-                                        "items": {"type": "number"}
-                                    },
-                                    "bbox": {
-                                        "type": "array",
-                                        "minItems": 4,
-                                        "items": {"type": "number"}
-                                    }
-                                }
-                            },
-                            {
-                                "title": "GeoJSON LineString",
-                                "type": "object",
-                                "required": [
-                                    "type",
-                                    "coordinates"
-                                ],
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": ["LineString"]
-                                    },
-                                    "coordinates": {
-                                        "type": "array",
-                                        "minItems": 2,
-                                        "items": {
-                                            "type": "array",
-                                            "minItems": 2,
-                                            "items": {"type": "number"}
-                                        }
-                                    },
-                                    "bbox": {
-                                        "type": "array",
-                                        "minItems": 4,
-                                        "items": {"type": "number"}
-                                    }
-                                }
-                            },
-                            {
-                                "title": "GeoJSON Polygon",
-                                "type": "object",
-                                "required": [
-                                    "type",
-                                    "coordinates"
-                                ],
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": ["Polygon"]
-                                    },
-                                    "coordinates": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "array",
-                                            "minItems": 4,
-                                            "items": {
-                                                "type": "array",
-                                                "minItems": 2,
-                                                "items": {"type": "number"}
-                                            }
-                                        }
-                                    },
-                                    "bbox": {
-                                        "type": "array",
-                                        "minItems": 4,
-                                        "items": {"type": "number"}
-                                    }
-                                }
-                            },
-                            {
-                                "title": "GeoJSON MultiPoint",
-                                "type": "object",
-                                "required": [
-                                    "type",
-                                    "coordinates"
-                                ],
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": ["MultiPoint"]
-                                    },
-                                    "coordinates": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "array",
-                                            "minItems": 2,
-                                            "items": {"type": "number"}
-                                        }
-                                    },
-                                    "bbox": {
-                                        "type": "array",
-                                        "minItems": 4,
-                                        "items": {"type": "number"}
-                                    }
-                                }
-                            },
-                            {
-                                "title": "GeoJSON MultiLineString",
-                                "type": "object",
-                                "required": [
-                                    "type",
-                                    "coordinates"
-                                ],
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": ["MultiLineString"]
-                                    },
-                                    "coordinates": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "array",
-                                            "minItems": 2,
-                                            "items": {
-                                                "type": "array",
-                                                "minItems": 2,
-                                                "items": {"type": "number"}
-                                            }
-                                        }
-                                    },
-                                    "bbox": {
-                                        "type": "array",
-                                        "minItems": 4,
-                                        "items": {"type": "number"}
-                                    }
-                                }
-                            },
-                            {
-                                "title": "GeoJSON MultiPolygon",
-                                "type": "object",
-                                "required": [
-                                    "type",
-                                    "coordinates"
-                                ],
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "enum": ["MultiPolygon"]
-                                    },
-                                    "coordinates": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "array",
-                                                "minItems": 4,
-                                                "items": {
-                                                    "type": "array",
-                                                    "minItems": 2,
-                                                    "items": {"type": "number"}
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "bbox": {
-                                        "type": "array",
-                                        "minItems": 4,
-                                        "items": {"type": "number"}
-                                    }
-                                }
-                            }
-                        ]
-                    }
-                },
-                "bbox": {
-                    "type": "array",
-                    "minItems": 4,
-                    "items": {"type": "number"}
-                }
-            }
+          "$ref": "./Schema_LayeredGeoJSON.json"
         }
-    ]
+      ]
+    },
+    "geometryCollection": {
+      "allOf": [
+        {
+          "title": "GeoJSON GeometryCollection",
+          "type": "object",
+          "required": [
+            "type",
+            "geometries"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["GeometryCollection"]
+            },
+            "geometries": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/normalGeometry"
+              }
+            },
+            "bbox": {
+              "type": "array",
+              "minItems": 4,
+              "items": {"type": "number"}
+            }
+          }
+        },
+        {
+          "$ref": "./Schema_LayeredGeoJSON.json"
+        }
+      ]
+    }
+  },
+  "oneOf": [
+    {
+      "$ref": "#/definitions/normalGeometry"
+    },
+    {
+      "$ref": "#/definitions/geometryCollection"
+    }
+  ]
 }

--- a/schema/Schema_LayeredGeoJSON.json
+++ b/schema/Schema_LayeredGeoJSON.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "LayeredGeoJSON members",
+  "description": "A vertical layer extent for all standard GeoJSON geometries",
+  "type": "object",
+  "definitions": {
+    "verticalReference": {
+      "description": "A code indicating a vertical reference system. Allowed values:\nAGL = Above ground level (or above water surface, as applicable)\nAMSL = Above Mean Sea Level\nWGS84 = Above the surface of the WGS-84 ellipsoid (Ellipsoidal height)",
+      "type": "string",
+      "enum": [
+        "AGL",
+        "AMSL",
+        "WGS84"
+      ]
+    }
+  },
+  "properties": {
+    "layer": {
+      "type": "object",
+      "properties": {
+        "upper": {
+          "description": "The value of the upper limit of the airspace layer expressed in metres (m) or feet (ft), in relation with the vertical datum specified in the upperReference property. A positive value is interpreted as meaning \"above\" the reference surface.",
+          "type": "number"
+        },
+        "upperReference": {
+          "$ref": "#/definitions/verticalReference"
+        },
+        "lower": {
+          "description": "The value of the lower limit of the airspace layer expressed in metres (m) or feet (ft), in relation with the vertical datum specified in the lowerReference property. A positive value is interpreted as meaning \"above\" the reference surface.",
+          "type": "number"
+        },
+        "lowerReference": {
+          "$ref": "#/definitions/verticalReference"
+        },
+        "uom": {
+          "description": "The unit of measurement in which the upper and lower values are expressed. Allowable values:\nm = metres\nft = feet\nIf this member is not specified, the units should be assumed to be metres.",
+          "type": "string",
+          "enum": [
+            "m",
+            "ft"
+          ],
+          "default": "m"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds validation when [LayeredGeoJSON](https://github.com/LayeredGeoJSON/LayeredGeoJSON-Specification) is used to define circles and/or vertical extents.

The largest change in terms of lines affected is that, instead of duplicating the definitions of all geometry types within GeometryCollection like [the GeoJSON schema](https://geojson.org/schema/GeoJSON.json) does, this PR defines the "normal" (not GeometryCollection) geometry types once and reuses that definition both in the root and for items of GeometryCollection's `geometries`.

It does not currently enforce specification of both the value and reference for a vertical limit (e.g., if `upper` is specified, `upperReference` must be specified as well).

All the examples have been confirmed to validate against these changes using the validation script in #1.