### PR TITLE
Fix metadata in Schema_GeoZones.json

### DIFF
--- a/examples/InvalidExample_GeoZone_2_Layers.json
+++ b/examples/InvalidExample_GeoZone_2_Layers.json
@@ -1,0 +1,137 @@
+{
+  "type": "FeatureCollection",
+  "title": "SampleUAS GeoZOnes",
+  "metadata": {
+    "validFrom": {
+      "purposely_invalid": "This object is not a datetime"
+    },
+    "issued": "2018-12-01T15:59:59Z"
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "GeometryCollection",
+        "geometries": [
+          {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  2.585866,
+                  49.029301
+                ],
+                [
+                  2.610414,
+                  48.983358
+                ],
+                [
+                  2.731263,
+                  48.987301
+                ],
+                [
+                  2.704141,
+                  49.044704
+                ],
+                [
+                  2.585866,
+                  49.029301
+                ]
+              ]
+            ],
+            "layer": {
+              "upper": 150,
+              "upperReference": "AGL",
+              "lower": 50,
+              "lowerReference": "AGL",
+              "uom": "m"
+            }
+          },
+          {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  2.595866,
+                  49.024301
+                ],
+                [
+                  2.701263,
+                  49.007301
+                ],
+                [
+                  2.664141,
+                  49.034704
+                ],
+                [
+                  2.595866,
+                  49.024301
+                ]
+              ]
+            ],
+            "layer": {
+              "upper": 50,
+              "upperReference": "AGL",
+              "lower": 0,
+              "lowerReference": "AGL",
+              "uom": "m"
+            }
+          }
+        ]
+      },
+      "properties": {
+        "identifier": "NFZ6547",
+        "country": "FRA",
+        "name": [
+          {"text": "LFPG-2"}
+        ],
+        "variant": "COMMON",
+        "type": "REQ_AUTHORISATION",
+        "reason": [
+          "AIR_TRAFFIC",
+          "OTHER"
+        ],
+        "otherReasonInfo": [
+          {
+            "text": "Flying Whales - part 2",
+            "lang": "en-GB"
+          },
+          {
+            "text": "Baleines Volantes 2-ème partie",
+            "lang": "fr-BE"
+          }
+        ],
+        "limitedApplicability": [
+          {
+            "startDateTime": "2018-12-31T15:59:59Z",
+            "endDateTime": "2019-12-31T15:59:59Z",
+            "schedule": [
+              {
+                "day": ["ANY"],
+                "startTime": "16:00:00Z",
+                "endTime": "17:00:00Z"
+              },
+              {
+                "day": ["SUN"],
+                "startTime": "10:00:00Z",
+                "endTime": "12:00:00Z"
+              }
+            ]
+          }
+        ],
+        "zoneAuthority": [
+          {
+            "name": [
+              {
+                "text": "LFPG-UASZoneManager",
+                "lang": "en-us"
+              }
+            ],
+            "email": "UASZoneManager@lfpg.fr",
+            "purpose": "AUTHORIZATION"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/schema/Schema_GeoZones.json
+++ b/schema/Schema_GeoZones.json
@@ -100,16 +100,11 @@
                     "type": "array",
                     "minItems": 4,
                     "items": {"type": "number"}
+                },
+                "metadata": {
+                    "$ref": "./Schema_GeoZoneCollectionMetadata.json"
                 }
             }
         }
-    ],
-    "bbox": {
-        "type": "array",
-        "minItems": 4,
-        "items": {"type": "number"}
-    },
-    "metadata": {
-        "$ref": "./Schema_GeoZoneCollectionMetadata.json"
-    }
+    ]
 }


### PR DESCRIPTION
Currently, Schema_GeoZones.json has two dangling top-level keys that don't accomplish anything with regard to validation (`metadata` and `bbox`).  To demonstrate this, this PR adds what I believe is an invalid FeatureCollection example (its `metadata` is poorly-formed) and tests to ensure that validation of that example contains errors.  Initially, there were no validation errors, but the adjustment of Schema_GeoZones.json in this PR fixes that problem by moving `metadata` to a property of FeatureCollection.