### PR TITLE
fix: example files according to schema

### DIFF
--- a/examples/Example_Collection.json
+++ b/examples/Example_Collection.json
@@ -1,6 +1,6 @@
 {
     "type": "FeatureCollection",
-    "name": "SampleUAS GeoZOnes",
+    "name": "SampleUAS GeoZones",
     "metadata": {
         "validFrom": "2018-12-31T15:59:59Z",
         "issued": "2018-12-01T15:59:59Z"
@@ -123,7 +123,7 @@
                         "name": [
                             {
                                 "text": "LFPG-UASZoneManager",
-                                "lang": "en-us"
+                                "lang": "en-US"
                             }
                         ],
                         "email": "UASZoneManager@lfpg.fr",
@@ -141,7 +141,7 @@
                     50.122901
                 ],
                 "extent": {
-                    "subType": "Circles",
+                    "subType": "Circle",
                     "radius": 3500
                 },
                 "layer": {
@@ -180,7 +180,7 @@
                         "name": [
                             {
                                 "text": "LFPG-UASZoneManager",
-                                "lang": "en-us"
+                                "lang": "en-US"
                             }
                         ],
                         "email": "UASZoneManager@lfpg.fr",

--- a/examples/Example_GeoZone_2_Layers.json
+++ b/examples/Example_GeoZone_2_Layers.json
@@ -1,6 +1,6 @@
 {
     "type": "FeatureCollection",
-    "title": "SampleUAS GeoZOnes",
+    "title": "SampleUAS GeoZones",
     "metadata": {
         "validFrom": "2018-12-31T15:59:59Z",
         "issued": "2018-12-01T15:59:59Z"
@@ -123,7 +123,7 @@
                         "name": [
                             {
                                 "text": "LFPG-UASZoneManager",
-                                "lang": "en-us"
+                                "lang": "en-US"
                             }
                         ],
                         "email": "UASZoneManager@lfpg.fr",

--- a/examples/Example_GeoZone_Circle.json
+++ b/examples/Example_GeoZone_Circle.json
@@ -1,6 +1,6 @@
 {
     "type": "FeatureCollection",
-    "title": "SampleUAS GeoZOnes",
+    "title": "SampleUAS GeoZones",
     "metadata": {
         "validFrom": "2018-12-31T15:59:59Z",
         "issued": "2018-12-01T15:59:59Z"
@@ -15,7 +15,7 @@
                     50.122901
                 ],
                 "extent": {
-                    "subType": "Circles",
+                    "subType": "Circle",
                     "radius": 3500
                 },
                 "layer": {
@@ -54,7 +54,7 @@
                         "name": [
                             {
                                 "text": "LFPG-UASZoneManager",
-                                "lang": "en-us"
+                                "lang": "en-US"
                             }
                         ],
                         "email": "UASZoneManager@lfpg.fr",

--- a/examples/Example_GeoZone_with_extension.json
+++ b/examples/Example_GeoZone_with_extension.json
@@ -1,6 +1,6 @@
 {
     "type": "FeatureCollection",
-    "title": "SampleUAS GeoZOnes",
+    "title": "SampleUAS GeoZones",
     "metadata": {
         "validFrom": "2018-12-31T15:59:59Z",
         "issued": "2018-12-01T15:59:59Z"
@@ -15,7 +15,7 @@
                     50.122901
                 ],
                 "extent": {
-                    "subType": "Circles",
+                    "subType": "Circle",
                     "radius": 3500
                 },
                 "layer": {
@@ -54,7 +54,7 @@
                         "name": [
                             {
                                 "text": "LFPG-UASZoneManager",
-                                "lang": "en-us"
+                                "lang": "en-US"
                             }
                         ],
                         "email": "UASZoneManager@lfpg.fr",

--- a/examples/InvalidExample_GeoZone_2_Layers.json
+++ b/examples/InvalidExample_GeoZone_2_Layers.json
@@ -1,6 +1,6 @@
 {
   "type": "FeatureCollection",
-  "title": "SampleUAS GeoZOnes",
+  "title": "SampleUAS GeoZones",
   "metadata": {
     "validFrom": {
       "purposely_invalid": "This object is not a datetime"
@@ -124,7 +124,7 @@
             "name": [
               {
                 "text": "LFPG-UASZoneManager",
-                "lang": "en-us"
+                "lang": "en-US"
               }
             ],
             "email": "UASZoneManager@lfpg.fr",

--- a/examples/PartialExample_GeoZoneProperties.json
+++ b/examples/PartialExample_GeoZoneProperties.json
@@ -44,7 +44,7 @@
             "name": [
                 {
                     "text": "LFPG-UASZoneManager",
-                    "lang": "en-us"
+                    "lang": "en-US"
                 }
             ],
             "email": "UASZoneManager@lfpg.fr",

--- a/examples/PartialExample_TimePeriod.json
+++ b/examples/PartialExample_TimePeriod.json
@@ -1,16 +1,16 @@
 {
-                        "startDateTime": "2023-10-29T00:00:00Z",
-                        "endDateTime": "2024-03-31T23:59:59Z",
-                        "schedule": [
-                            {
-                                "day": ["ANY"],
-                                "startTime": "16:00:00Z",
-                                "endTime": "17:00:00Z"
-                            },
-                            {
-                                "day": ["SUN"],
-                                "startTime": "10:00:00Z",
-                                "endTime": "12:00:00Z"
-                            }
-                        ]
-                    }
+    "startDateTime": "2023-10-29T00:00:00Z",
+    "endDateTime": "2024-03-31T23:59:59Z",
+    "schedule": [
+        {
+            "day": ["ANY"],
+            "startTime": "16:00:00Z",
+            "endTime": "17:00:00Z"
+        },
+        {
+            "day": ["SUN"],
+            "startTime": "10:00:00Z",
+            "endTime": "12:00:00Z"
+        }
+    ]
+}

--- a/examples/PartialExample_ZoneAuthority.json
+++ b/examples/PartialExample_ZoneAuthority.json
@@ -2,11 +2,11 @@
     "name": [
         {
             "text": " Civil Aviation Authority",
-            "lang": "en-gb"
+            "lang": "en-GB"
         },
         {
             "text": " Civil Aviation Authority",
-            "lang": "fr-fr"
+            "lang": "fr-FR"
         }
     ],
     "purpose": "NOTIFICATION"

--- a/examples/PartialExample_featureGeoJSON.json
+++ b/examples/PartialExample_featureGeoJSON.json
@@ -115,7 +115,7 @@
                 "name": [
                     {
                         "text": "LFPG-UASZoneManager",
-                        "lang": "en-us"
+                        "lang": "en-US"
                     }
                 ],
                 "email": "UASZoneManager@lfpg.fr",


### PR DESCRIPTION
When validating the examples against the GeoJson schema files it creates errors because of incorrect types. Following changes and improvements were made to comply with ED-318:
* fix capitalization in `name` fields
* fix capitalization in `lang` fields (see 4.2.5.10 of ED-318)
* fix subtype to `Circle` (see 4.2.3.1 of ED-318)