### PR TITLE
fix: missing property dataSource in UASZoneVersion

### DIFF
--- a/schema/Schema_GeoZoneDataTypes.json
+++ b/schema/Schema_GeoZoneDataTypes.json
@@ -104,7 +104,23 @@
             },
             "required": ["lang"]
         },
-        "URNType": {"type": "string"}
+        "URNType": {"type": "string"},
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "creationDate": {
+                    "type": "string",
+                    "format": "DateTimeType"
+                },
+                "updateDateTime": {
+                    "type": "string",
+                    "format": "DateTimeType"
+                },
+                "originator": {
+                    "$ref": "#/definitions/textShortType"
+                }
+            }
+        }
     },
     "properties": {},
     "required": []

--- a/schema/Schema_GeoZoneProperties.json
+++ b/schema/Schema_GeoZoneProperties.json
@@ -48,6 +48,7 @@
             "type": "array",
             "items": {"$ref": "./Schema_GeoZoneTimePeriod.json"}
         },
+        "dataSource": {"$ref": "./Schema_GeoZoneDataTypes.json#/definitions/metadata"},
         "extendedProperties": {"type": "object"}
     },
     "required": [


### PR DESCRIPTION
There is an inconsistency in the ED-318 standard concerning the "dataset" property of the "UASZoneVersion" type. The diagram under section 4.2.1 and section 4.2.4.2 state that the "UASZoneVersion" type should have an optional "dataSource" property of type DataSet. In comparison the "Schema_GeoZoneProperties.json" in Appendix C does not list the "dataSource" property.
 
I assume the property is missing in the JSON schema. Therefore I propose to add the property "dataSource" to the JSON Schemas.